### PR TITLE
manually updated node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gray-matter": "^4.0.2",
     "marked": "^1.1.0",
     "next": "^9.3.6",
+    "node-fetch": "^2.6.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "sass": "^1.26.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4154,6 +4154,11 @@ node-fetch@2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-html-parser@^1.2.19:
   version "1.2.21"
   resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.2.21.tgz#93b074d877007c7148d594968a642cd65d254daa"


### PR DESCRIPTION
 Vulnerable versions: < 2.6.1
Patched version: 2.6.1
## Impact

Node Fetch did not honor the size option after following a redirect, which means that when a content size was over the limit, a FetchError would never get thrown and the process would end without failure.

For most people, this fix will have a little or no impact. However, if you are relying on node-fetch to gate files above a size, the impact could be significant, for example: If you don't double-check the size of the data after fetch() has completed, your JS thread could get tied up doing work on a large file (DoS) and/or cost you money in computing.
## Patches

We released patched versions for both stable and beta channels:

    For v2: 2.6.1
    For v3: 3.0.0-beta.9

## Workarounds

None, it is strongly recommended to update as soon as possible.
For more information

If you have any questions or comments about this advisory:

    Open an issue in node-fetch
    Contact one of the core maintainers.

