### PR TITLE
[Manual] Bump marked from 1.1.1. to 4.0.10

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
-    "marked": "^1.1.0",
+    "marked": "^4.0.10",
     "next": "12",
     "node-fetch": "^2.6.1",
     "react": "^17.0.2",
@@ -24,7 +24,7 @@
     "sass": "^1.26.5"
   },
   "devDependencies": {
-    "@types/marked": "^0.7.4",
+    "@types/marked": "^4.0.3",
     "@types/node": "^13.13.4",
     "@types/react": "^17.0.45",
     "@typescript-eslint/eslint-plugin": "^2.30.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import marked from 'marked';
+import { marked } from 'marked';
 import { GetStaticProps } from 'next';
 
 import { getWritingBySlug } from '../lib/api';
@@ -37,7 +37,7 @@ const JoshuaDavid: React.FC<Props> = ({ content }) => {
 export const getStaticProps: GetStaticProps = async () => {
     const { content } = getWritingBySlug('about', ['content']);
     return {
-        props: { content: marked(content as string) }
+        props: { content: marked.parse(content as string) }
     }
 }
 

--- a/pages/writings/[slug].tsx
+++ b/pages/writings/[slug].tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
-import marked from 'marked';
+import { marked } from 'marked';
 // components
 import { Layout, Title, Content } from '../../components';
 import Link from 'next/link';
@@ -95,7 +95,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     'coverImage',
   ];
   const writing = getWritingBySlug(params?.slug as string, fields);
-  const content = marked(writing.content as string);
+  const content = marked.parse(writing.content as string);
   return {
     props: {
       ...writing,

--- a/scripts/rssGenerator.js
+++ b/scripts/rssGenerator.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const { join } = require('path');
 const matter = require('gray-matter');
-const marked = require('marked');
+const { marked } = require('marked');
 
 const RSS_PATH = join(process.cwd(), 'public/rss.xml');
 const WRITINGS_PATH = join(process.cwd(), '_writings');
@@ -89,7 +89,7 @@ function writeItem(WRITINGS_PATH, fileContent, slug) {
   let item = `<item>`;
   item += `<title>${data.title}</title>`;
   item += `<dc:creator>${data.author}</dc:creator>`;
-  item += `<description><![CDATA[${marked(content)}]]></description>`;
+  item += `<description><![CDATA[${marked.parse(content)}]]></description>`;
   item += `<pubDate>${new Date(data.date).toUTCString()}</pubDate>`;
   item += `<link>https://jdnordstrom.com/writings/${realSlug}</link>`;
   item += `<guid isPermaLink="true">https://jdnordstrom.com/writings/${realSlug}</guid>`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "incremental": true
   },
   "exclude": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,10 +113,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/marked@^0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.7.4.tgz#607685669bb1bbde2300bc58ba43486cbbee1f0a"
-  integrity sha512-fdg0NO4qpuHWtZk6dASgsrBggY+8N4dWthl1bAQG9ceKUNKFjqpHaDKCAhRUI6y8vavG7hLSJ4YBwJtZyZEXqw==
+"@types/marked@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.3.tgz#2098f4a77adaba9ce881c9e0b6baf29116e5acc4"
+  integrity sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==
 
 "@types/node@^13.13.4":
   version "13.13.52"
@@ -1297,10 +1297,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-marked@^1.1.0:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
+marked@^4.0.10:
+  version "4.0.16"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.16.tgz#9ec18fc1a723032eb28666100344d9428cf7a264"
+  integrity sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==
 
 mimic-fn@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
### Description
Required code changes for version upgrade:
- upgrade @types/marked to 4.0.3
- "marked" is no longer a default export, need to import explicitly
- "marked" is no longer a function, need to call marked.parse()

### References
- https://marked.js.org/#usage